### PR TITLE
fix alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.6
 MAINTAINER Sven Walter <sven@wltr.eu>
 
 ARG SYNCTHING_VERSION=v0.14.28


### PR DESCRIPTION
Alpine 3.6 was released, so we don't have to use edge anymore.